### PR TITLE
Allow param interpolation in removePath.

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -92,7 +92,7 @@ export default (formatPattern) => {
             ...typeof relocation === 'string' ? {type: relocation} : relocation,
 
             removePath: relocation.removePath !== undefined ?
-              relocation.removePath :
+              finalFormatPattern(relocation.removePath, params) :
               getFormattedPathName(i - 1),
           });
         }


### PR DESCRIPTION
Allow custom `removePath` values to contain route params. This behavior matches the automatic `removePath` creation logic.