### PR TITLE
Remove previousPath related logic.

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -2,7 +2,6 @@ import cuid from 'cuid';
 
 export const ADD_COMPONENT = '@@relocation/ADD_COMPONENT';
 export const REMOVE_COMPONENT = '@@relocation/REMOVE_COMPONENT';
-export const SET_PREVIOUS_PATH = '@@relocation/SET_PREVIOUS_PATH';
 export const SET_ROUTE_COMPONENTS = '@@relocation/SET_ROUTE_COMPONENTS';
 
 export const addComponent = ({type, props, id = cuid()}) => ({
@@ -11,11 +10,6 @@ export const addComponent = ({type, props, id = cuid()}) => ({
 });
 
 export const removeComponent = (id) => ({type: REMOVE_COMPONENT, payload: id});
-
-export const setPreviousPath = (path) => ({
-  type: SET_PREVIOUS_PATH,
-  payload: path,
-});
 
 export const setRouteComponents = (components) => ({
   type: SET_ROUTE_COMPONENTS,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -2,7 +2,6 @@ import {combineReducers} from 'redux';
 import {
   REMOVE_COMPONENT,
   ADD_COMPONENT,
-  SET_PREVIOUS_PATH,
   SET_ROUTE_COMPONENTS,
 } from './action';
 
@@ -16,5 +15,4 @@ export default combineReducers({
       state.filter((item) => item.id !== payload),
   }[action.type] || (() => state))(state, action),
   routeComponents: createReducer(SET_ROUTE_COMPONENTS, []),
-  previousPath: createReducer(SET_PREVIOUS_PATH, ''),
 });

--- a/src/router.js
+++ b/src/router.js
@@ -2,7 +2,7 @@ import {Component, PropTypes, Children} from 'react';
 import {connect} from 'react-redux';
 import invariant from 'fbjs/lib/invariant';
 
-import {setRouteComponents, setPreviousPath} from './action';
+import {setRouteComponents} from './action';
 
 /**
  * [description]
@@ -36,7 +36,6 @@ export default (formatPattern) => {
     }
 
     componentWillReceiveProps(nextProps) {
-      this.updatePreviousPath(nextProps);
       this.updateRouteComponents(nextProps);
     }
 
@@ -101,15 +100,6 @@ export default (formatPattern) => {
       }, []);
 
       dispatch(setRouteComponents(components));
-    }
-
-    updatePreviousPath(nextProps) {
-      const {location: {pathname: previousPath}, dispatch} = this.props;
-      const {location: {pathname: currentPath}} = nextProps;
-
-      if (previousPath && previousPath !== currentPath) {
-        dispatch(setPreviousPath(previousPath));
-      }
     }
 
     render() {

--- a/src/selector.js
+++ b/src/selector.js
@@ -11,9 +11,6 @@ export const getComponents = (state, props) =>
 export const getRouteComponents = (state, props) =>
   getRelocation(state, props).routeComponents;
 
-export const getPreviousPath = (state, props) =>
-  getRelocation(state, props).previousPath;
-
 export const getMergedComponents = (state, props) =>
   [...getRouteComponents(state, props), ...getComponents(state, props)].
     reduce((components, component) => {


### PR DESCRIPTION
Remove the previousPath reducer and related conditional `router.goBack` logic. This never really worked correctly in practice since using the back function of history leaves the reducer with the wrong `previousPath` value (actually the "next" path). A proper solution would be to store an array of location history, and push or pop the location on navigation.

It's better to just keep things simple.