### PR TITLE
Refactor connector config and introduce scope.

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -12,6 +12,7 @@ export const renderMapShape = PropTypes.objectOf(renderShape);
 export const componentShape = PropTypes.shape({
   id: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
+  scope: PropTypes.string,
   props: PropTypes.object,
   remove: PropTypes.func,
   removePath: PropTypes.string,


### PR DESCRIPTION
All of the `relocation` connector config can be assigned as props on the connected component instance or configured within the call to the `relocation` connector.

Instead of taking separate render map and config parameters, the connector now takes a single default props object. The render map can be defined within as `components` or can be provided as a `components` prop on the rendered instance.

In addition an optional `scope` option allows namespacing the consumed and generated props. This is designed to prevent conflicts with existing props on the connected component and allows composition with multiple `relocation` connector calls on the same component.