### PR TITLE
Simplify actions and selectors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "license": "CC0-1.0",
   "dependencies": {
-    "core-js": "^2.4.1",
     "cuid": "^1.3.8",
     "fbjs": "^0.8.4",
     "hoist-non-react-statics": "^1.2.0"

--- a/src/action.js
+++ b/src/action.js
@@ -1,15 +1,30 @@
 import cuid from 'cuid';
 
 export const ADD_COMPONENT = '@@relocation/ADD_COMPONENT';
+export const SET_COMPONENT = '@@relocation/SET_COMPONENT';
+export const UPDATE_COMPONENT = '@@relocation/UPDATE_COMPONENT';
 export const REMOVE_COMPONENT = '@@relocation/REMOVE_COMPONENT';
 export const SET_ROUTE_COMPONENTS = '@@relocation/SET_ROUTE_COMPONENTS';
 
-export const addComponent = ({type, props, id = cuid()}) => ({
+export const addComponent = (type, props) => ({
   type: ADD_COMPONENT,
+  payload: {id: cuid(), type, props},
+});
+
+export const setComponent = (type, id = type, props) => ({
+  type: SET_COMPONENT,
   payload: {id, type, props},
 });
 
-export const removeComponent = (id) => ({type: REMOVE_COMPONENT, payload: id});
+export const updateComponent = (id, props) => ({
+  type: UPDATE_COMPONENT,
+  payload: {id, props},
+});
+
+export const removeComponent = (id) => ({
+  type: REMOVE_COMPONENT,
+  payload: {id},
+});
 
 export const setRouteComponents = (components) => ({
   type: SET_ROUTE_COMPONENTS,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,18 +1,33 @@
 import {combineReducers} from 'redux';
 import {
-  REMOVE_COMPONENT,
   ADD_COMPONENT,
+  SET_COMPONENT,
+  UPDATE_COMPONENT,
+  REMOVE_COMPONENT,
   SET_ROUTE_COMPONENTS,
 } from './action';
 
-const createReducer = (type, initial) =>
-  (state = initial, action) => action.type === type ? action.payload : state;
-
 export default combineReducers({
   components: (state = [], action) => ({
-    [ADD_COMPONENT]: (state, {payload}) => [...state, payload],
+    [ADD_COMPONENT]: (state, {payload}) =>
+      [...state, payload],
+
+    [SET_COMPONENT]: (state, {payload}) =>
+      [...state.filter((item) => item.id !== payload.id), payload],
+
+    [UPDATE_COMPONENT]: (state, {payload}) =>
+      state.map((item) => item.id === payload.id
+        ? {...item, props: {...item.props, ...payload.props}}
+        : item
+      ),
+
     [REMOVE_COMPONENT]: (state, {payload}) =>
-      state.filter((item) => item.id !== payload),
+      state.filter((item) => item.id !== payload.id),
+
   }[action.type] || (() => state))(state, action),
-  routeComponents: createReducer(SET_ROUTE_COMPONENTS, []),
+
+  routeComponents: (state = [], action) =>
+    action.type === SET_ROUTE_COMPONENTS
+      ? action.payload
+      : state,
 });

--- a/src/selector.js
+++ b/src/selector.js
@@ -1,38 +1,16 @@
-import findIndex from 'core-js/library/fn/array/find-index';
-
 export const getRelocation = (state, props) =>
-  (props && props.getRelocationState) ?
-  props.getRelocationState(state, props) :
-  state.relocation;
+  (props && props.getRelocationState)
+    ? props.getRelocationState(state, props)
+    : state.relocation;
 
-export const getComponents = (state, props) =>
-  getRelocation(state, props).components;
+export const getComponents = (state, props) => {
+  const routeComponents = getRelocation(state, props).routeComponents;
+  const components = getRelocation(state, props).components;
 
-export const getRouteComponents = (state, props) =>
-  getRelocation(state, props).routeComponents;
-
-export const getMergedComponents = (state, props) =>
-  [...getRouteComponents(state, props), ...getComponents(state, props)].
-    reduce((components, component) => {
-      const index = findIndex(components, ({id}) => id === component.id);
-
-      if (index === -1) {
-        components.push(component);
-        return components;
-      }
-
-      const existing = components[index];
-
-      components[index] = {
-        ...existing,
-        ...component,
-        ...existing.props && component.props ? {
-          props: {
-            ...existing.props,
-            ...component.props,
-          },
-        } : null,
-      };
-
-      return components;
-    }, []);
+  // Concat components and route components uniquely by id.
+  return routeComponents
+    .filter(({id: routeId}) =>
+      !components.filter(({id}) => id === routeId).length
+    )
+    .concat(components);
+};


### PR DESCRIPTION
Remove the prop merging magic from the selectors. The original intention was to allow multiple instances of a component with a given id to exist, but to have them collapsed down and merged in the selector. This would have been useful for a component that was the product of props from a route component _and_ a dispatched component. However the complexity this added far outweighed the benefit, and the behavior was not intuitive.

The new version of `addComponent` no longer has the option for a custom id, and will not result in props merging with existing components.

A new `setComponent` action is used when the id must be explicitly specified. If an existing component with the given id exists, it is replaced rather than merged on to.

What does remain of the component merging logic is a new `updateComponent` action that can be used to update the props of an existing component. Props dispatched in the `updateComponent` _are_ merged into the existing props of the component with the matching id. An `update` function is also now included alongside the `remove` function on each component returned through the connector. This offers an interface for updating the state of the component (where `update` is used like react `setState`).