### PR TITLE
Strip `engines` from `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,5 @@
     "react-redux": "^4.4.5",
     "react-router": "^2.7.0",
     "redux": "^3.5.2"
-  },
-  "engines": {
-    "node": "6.3.1"
   }
 }


### PR DESCRIPTION
It's obviously compatible with more than just node 6.