### PR TITLE
Support `components` as a function.

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -33,11 +33,17 @@ export default ({scope, ...defaultProps} = {}) => (WrappedComponent) => {
     }
 
     render() {
-      const {components, renderMap} = this.props.___relocationState___;
+      const {
+        components,
+        renderMap: rawRenderMap,
+      } = this.props.___relocationState___;
       const {
         removeComponent,
         updateComponent,
       } = this.props.___relocationDispatch___;
+
+      const renderMap = typeof rawRenderMap === 'function' ?
+        rawRenderMap(this.props) : rawRenderMap;
 
       const inRenderMap = (component) =>
         typeof renderMap[component.type] === 'function';

--- a/src/util.js
+++ b/src/util.js
@@ -7,7 +7,10 @@ export const renderShape = PropTypes.oneOfType([
   PropTypes.string,
 ]);
 
-export const renderMapShape = PropTypes.objectOf(renderShape);
+export const renderMapShape = PropTypes.oneOfType([
+  PropTypes.func,
+  PropTypes.objectOf(renderShape),
+]);
 
 export const componentShape = PropTypes.shape({
   id: PropTypes.string.isRequired,


### PR DESCRIPTION
Normally `components` is provided as a static map but this doesn't let you do fancy things. By allowing `components` to be a function that map can be calculated when the component renders, enabling additional flexibility. One such use case is dependency injection: you have some relocation components you want to _register themselves_ instead of managing a global map. This can be achieved with a components file:

```javascript
const map = {};

export const register = (id, component) => {
  if (map[id]) {
    throw new TypeError(`Relocation component ${id} already exists.`);
  }
  map[id] = component;
  return component;
}

export const components = () => map;

export default components;
```

A relocation component:

```javascript
import {register} from '...'
export const RELOCATION_ID = '...';

export default register(RELOCATION_ID, (props) => {
  return <div>{props.message}</div>;
});
```

And a consumer of that component:

```javascript
import {RELOCATION_ID as SPECIAL_MESSAGE} from '...';

export default ({setComponent}) => (
  <button onClick={() => setComponent(SPECIAL_MESSAGE, 'id', {message: 'foo'})}>
    Hi
  </button>
);
```