### PR TITLE
Add initial tests and coverage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 *.js
 *.js.map
 !src/**/*.js
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,7 @@ sudo: false
 language: node_js
 matrix:
   include:
-    # Run tests in Node.js 6.x
     - node_js: '6'
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-4.8
-            - g++-4.8
-
-before_install:
-  # Use GCC 4.8 if it's available
+after_success:
+  - cat ./coverage/coverage.json | ./node_modules/.bin/adana -F adana-format-istanbul > ./coverage/istanbul.json
+  - bash <(curl -s https://codecov.io/bash) -f ./coverage/istanbul.json

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,3 @@
+parsers:
+  javascript:
+    enable_partials: yes

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d . src",
     "lint": "./node_modules/.bin/eslint .",
-    "test": "npm run lint"
+    "spec": "NODE_ENV=test ./node_modules/.bin/_mocha -r adana-dump --compilers js:babel-core/register -R spec --recursive test/spec/**/*.spec.js",
+    "test": "npm run lint && npm run spec"
   },
   "author": "Neal Granger <neal@metalab.co>",
   "repository": {
@@ -25,17 +26,26 @@
     "redux": "^3.5.2"
   },
   "devDependencies": {
+    "adana-cli": "^0.1.2",
+    "adana-dump": "^0.1.0",
+    "adana-format-istanbul": "^0.1.1",
     "babel-cli": "^6.14.0",
-    "babel-preset-metalab": "^0.2.1",
-    "eslint": "^2.10.2",
-    "eslint-config-metalab": "^4.0.1",
-    "eslint-plugin-filenames": "^0.2.0",
-    "eslint-plugin-import": "^1.13.0",
-    "eslint-plugin-lodash-fp": "^1.2.0",
-    "eslint-plugin-react": "^5.1.1",
+    "babel-preset-metalab": "^1.0.0",
+    "eslint": "^3.19.0",
+    "eslint-config-metalab": "^6.0.1",
+    "eslint-plugin-babel": "^4.1.1",
+    "eslint-plugin-filenames": "^1.2.0",
+    "eslint-plugin-import": "^2.3.0",
+    "eslint-plugin-lodash-fp": "^2.1.3",
+    "eslint-plugin-react": "^7.0.1",
+    "mocha": "^3.4.2",
     "react": "^15.3.0",
+    "react-dom": "^15.5.4",
     "react-redux": "^4.4.5",
     "react-router": "^2.7.0",
-    "redux": "^3.5.2"
+    "react-test-renderer": "^15.5.4",
+    "redux": "^3.5.2",
+    "unexpected": "^10.29.0",
+    "unexpected-react": "^4.0.2"
   }
 }

--- a/src/connect.js
+++ b/src/connect.js
@@ -67,7 +67,7 @@ export default ({scope, ...defaultProps} = {}) => (WrappedComponent) => {
       const {
         ___relocationState___,
         ___relocationDispatch___,
-        ...childProps,
+        ...childProps
       } = this.props;
       /* eslint-enable no-unused-vars */
 

--- a/test/spec/.eslintrc
+++ b/test/spec/.eslintrc
@@ -1,0 +1,2 @@
+env:
+  mocha: true

--- a/test/spec/action.spec.js
+++ b/test/spec/action.spec.js
@@ -1,0 +1,38 @@
+import expect from 'unexpected';
+import {
+  addComponent,
+  setComponent,
+  updateComponent,
+  removeComponent,
+  ADD_COMPONENT,
+  SET_COMPONENT,
+  UPDATE_COMPONENT,
+  REMOVE_COMPONENT,
+} from '../../src/action';
+
+describe('action', () => {
+  it('should generate `addComponent` actions', () => {
+    const result = addComponent('foo');
+    expect(result, 'to satisfy', {
+      type: ADD_COMPONENT,
+    });
+  });
+  it('should generate `setComponent` actions', () => {
+    const result = setComponent('foo');
+    expect(result, 'to satisfy', {
+      type: SET_COMPONENT,
+    });
+  });
+  it('should generate `updateComponent` actions', () => {
+    const result = updateComponent('foo');
+    expect(result, 'to satisfy', {
+      type: UPDATE_COMPONENT,
+    });
+  });
+  it('should generate `removeComponent` actions', () => {
+    const result = removeComponent('foo');
+    expect(result, 'to satisfy', {
+      type: REMOVE_COMPONENT,
+    });
+  });
+});

--- a/test/spec/connect.spec.js
+++ b/test/spec/connect.spec.js
@@ -1,0 +1,33 @@
+import _expect from 'unexpected';
+import react from 'unexpected-react/test-renderer';
+import {create as render} from 'react-test-renderer';
+import {createElement} from 'react';
+import {createStore as baseCreateStore, combineReducers} from 'redux';
+import relocation from '../../src/reducer';
+import connect from '../../src/connect';
+import {setComponent} from '../../src/action';
+
+const expect = _expect.clone().use(react);
+
+const Base = ({components:[{id, props: {foo}}]}) => <div>{id} - {foo}</div>;
+
+const createStore = () => baseCreateStore(combineReducers({relocation}));
+
+describe('connect', () => {
+  it('should render a single component', () => {
+    const store = createStore();
+    const Component = connect()(Base);
+    store.dispatch(setComponent('TEST', 'banana', {foo: 5}));
+    const result = render(
+      <Component
+        components={{
+          TEST: ({foo}) => <div>Hi</div>
+        }}
+        store={store}
+      />
+    );
+    expect(result, 'to have rendered', (
+      <div>banana - 5</div>
+    ));
+  });
+});

--- a/test/spec/reducer.spec.js
+++ b/test/spec/reducer.spec.js
@@ -1,0 +1,40 @@
+import expect from 'unexpected';
+import {
+  addComponent,
+  setComponent,
+  updateComponent,
+  removeComponent,
+} from '../../src/action';
+import reduce from '../../src/reducer';
+
+describe('reducer', () => {
+  it('should handle `ADD_COMPONENT`', () => {
+    const props = {foo: 'bar'};
+    const result = reduce({}, addComponent('MY_TYPE', props));
+    expect(result, 'to satisfy', {
+      components: [{props}],
+    });
+  });
+  it('should handle `SET_COMPONENT`', () => {
+    const props = {foo: 'bar'};
+    const result = reduce({}, setComponent('MY_TYPE', 'id', props));
+    expect(result, 'to satisfy', {
+      components: [{id: 'id', props}],
+    });
+  });
+  it('should handle `UPDATE_COMPONENT`', () => {
+    const state = {components: [{id: 'id'}]};
+    const props = {foo: 'bar'};
+    const result = reduce({}, setComponent('MY_TYPE', 'id', props));
+    expect(result, 'to satisfy', {
+      components: [{id: 'id', props}],
+    });
+  });
+  it('should handle `REMOVE_COMPONENT`', () => {
+    const state = {components: [{id: 'id'}]};
+    const result = reduce(state, removeComponent('id'));
+    expect(result, 'to exhaustively satisfy', {
+      components: []
+    });
+  });
+});

--- a/test/spec/selector.spec.js
+++ b/test/spec/selector.spec.js
@@ -1,0 +1,28 @@
+import expect from 'unexpected';
+import {getRelocation, getComponents} from '../../src/selector';
+
+const state = {
+  relocation: {
+    components: 'foo',
+  },
+  baz: 'bar',
+};
+
+describe('selector', () => {
+  describe('getRelocation', () => {
+    it('should work with default state atom', () => {
+      const result = getRelocation(state);
+      expect(result, 'to satisfy', {components: 'foo'});
+    });
+    it('should work with custom selector', () => {
+      const result = getRelocation(state, {getRelocationState: (x) => x.baz});
+      expect(result, 'to equal', 'bar');
+    });
+  });
+  describe('getComponents', () => {
+    it('should work', () => {
+      const result = getComponents(state);
+      expect(result, 'to equal', 'foo');
+    });
+  });
+});

--- a/test/spec/util.spec.js
+++ b/test/spec/util.spec.js
@@ -1,0 +1,5 @@
+import expect from 'unexpected';
+
+describe('util', () => {
+
+});


### PR DESCRIPTION
Using `unexpected`, `mocha` and friends to verify the most basic behaviour of relocation. Includes coverage because coverage is fun.

This also updates the latest `lint` and `babel` presets.