### PR TITLE
Remove `context`, `defaultProps`, add `componentShouldMount`.

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -5,7 +5,18 @@ import {connect} from 'react-redux';
 
 import {getComponents} from './selector';
 import {removeComponent, updateComponent} from './action';
-import {componentsShape, renderMapShape, getDisplayName} from './util';
+import {componentsShape, instancesShape, getDisplayName} from './util';
+
+const getFinalComponents = (state, props) => {
+  const initial = getComponents(state, props);
+  const exists = (component) => {
+    return typeof props.components[component.type] === 'function';
+  };
+  const shouldMount = props.componentShouldMount || (() => true);
+  return initial.filter(
+    (component) => exists(component) && shouldMount(state, props, component)
+  );
+};
 
 /**
  * Create a higher-order wrapper which provides an array of components to render
@@ -17,66 +28,49 @@ import {componentsShape, renderMapShape, getDisplayName} from './util';
  * object.
  * @returns {Function} Higher-order component wrapper.
  */
-export default ({scope, ...defaultProps} = {}) => (WrappedComponent) => {
+export default () => (WrappedComponent) => {
   class Connect extends Component {
     static propTypes = {
       ___relocationDispatch___: PropTypes.shape({
         removeComponent: PropTypes.func.isRequired,
+        updateComponent: PropTypes.func.isRequired,
       }),
       ___relocationState___: PropTypes.shape({
         components: componentsShape.isRequired,
-        renderMap: renderMapShape.isRequired,
+        instances: instancesShape.isRequired,
       }).isRequired,
     };
 
-    static contextTypes = {
-      router: PropTypes.object,
-    }
-
     render() {
-      const {components, renderMap} = this.props.___relocationState___;
-      const {
-        removeComponent,
-        updateComponent,
-      } = this.props.___relocationDispatch___;
-
-      const inRenderMap = (component) =>
-        typeof renderMap[component.type] === 'function';
-
-      const assign = (component) => {
-        const result = {
-          ...component,
-          render: renderMap[component.type],
-          update: (props) => updateComponent(component.id, props),
-          remove: () => removeComponent(component.id),
-        };
-
-        if (scope) {
-          result.scope = scope;
-        }
-
-        return result;
-      };
-
-      const currentComponents = components
-        // Remove components not included in the render function map.
-        .filter(inRenderMap)
-        // Assign render update and remove functions and scope if it is defined.
-        .map(assign);
-
-      /* eslint-disable no-unused-vars */
       const {
         ___relocationState___,
         ___relocationDispatch___,
         ...childProps
       } = this.props;
-      /* eslint-enable no-unused-vars */
+
+      const {components, instances} = ___relocationState___;
+      const {
+        removeComponent,
+        updateComponent,
+      } = ___relocationDispatch___;
+
+      const assign = (component) => {
+        const result = {
+          ...component,
+          containerProps: childProps,
+          render: components[component.type],
+          update: (...args) => updateComponent(component.id, ...args),
+          remove: (...args) => removeComponent(component.id, ...args),
+        };
+
+        return result;
+      };
+
+      const currentComponents = instances.map(assign);
 
       const mergedProps = {
         ...childProps,
-        ...scope
-          ? {[scope]: {components: currentComponents}}
-          : {components: currentComponents},
+        components: currentComponents,
       };
 
       return <WrappedComponent {...mergedProps}/>;
@@ -86,23 +80,12 @@ export default ({scope, ...defaultProps} = {}) => (WrappedComponent) => {
   Connect.displayName = `Relocation(${getDisplayName(WrappedComponent)})`;
 
   const mapState = (state, props) => {
-    const mergedProps = {
-      ...defaultProps,
-      ...scope ? props[scope] : props,
-    };
-
-    const {components, getRelocationState} = mergedProps;
-
-    const selectorProps = getRelocationState
-      ? {getRelocationState, ...props}
-      : props;
-
     return {
       // Put everything in a ___relocationState___ namespace to avoid possible
       // conflict with existing props.
       ___relocationState___: {
-        components: getComponents(state, selectorProps),
-        renderMap: components,
+        instances: getFinalComponents(state, props),
+        components: props.components,
       },
     };
   };

--- a/src/util.js
+++ b/src/util.js
@@ -2,21 +2,21 @@ import {PropTypes} from 'react';
 
 export const getDisplayName = (C) => C.displayName || C.name || 'Component';
 
-export const renderShape = PropTypes.oneOfType([
+export const componentShape = PropTypes.oneOfType([
   PropTypes.func,
   PropTypes.string,
 ]);
 
-export const renderMapShape = PropTypes.objectOf(renderShape);
+export const componentsShape = PropTypes.objectOf(componentShape);
 
-export const componentShape = PropTypes.shape({
+export const instanceShape = PropTypes.shape({
   id: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
   scope: PropTypes.string,
   props: PropTypes.object,
   remove: PropTypes.func,
   update: PropTypes.func,
-  render: renderShape,
+  render: componentShape,
 });
 
-export const componentsShape = PropTypes.arrayOf(componentShape);
+export const instancesShape = PropTypes.arrayOf(instanceShape);


### PR DESCRIPTION
The previous `context` property was basically used to isolate slices of `redux` for a particular component tree and `defaultProps` was used to pass in `components` as a convenience method. The `context` property can be emulated by either using `getRelocationState` or `componentShouldMount` now, and `defaultProps` just makes things messy internally, and one should just use `withProps` from `recompose`.

The new `componentShouldMount` is a mechanism for determining if a given component from the `redux` store should be passed through to the component decorated with `relocation()`. It has the signature `(state, props, component)` which mimics the `mapStateToProps` function of `redux` except that the third argument is the component from the store. Note that the `props` here come from the decorated component. This allows you much better control of determining what components from the large list of components in the store actually make it down.